### PR TITLE
update linter's doc

### DIFF
--- a/containedctx.go
+++ b/containedctx.go
@@ -8,9 +8,9 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-const doc = "containedctx is a linter that detects struct contained context.Context field"
+const doc = "A linter that detects structs containing a context.Context field."
 
-// Analyzer is the contanedctx analyzer
+// Analyzer is the containedctx analyzer
 var Analyzer = &analysis.Analyzer{
 	Name: "containedctx",
 	Doc:  doc,


### PR DESCRIPTION
The PR updates the linter's doc string by removing redundancy and improving grammar.

Before:
```
❯ go run cmd/containedctx/main.go help containedctx
containedctx: containedctx is a linter that detects struct contained context.Context field
```

After:
```
❯ go run cmd/containedctx/main.go help containedctx
containedctx: A linter that detects structs containing a context.Context field.
```