### PR TITLE
docs: fix install instruction

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,5 @@
 run:
   timeout: 5m
-  skip-files: []
 
 linters-settings:
   govet:
@@ -33,6 +32,6 @@ linters:
 
 issues:
   exclude-use-default: true
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
   exclude: []

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For rationale please read [Contexts and structs](https://go.dev/blog/context-and
 ## Instruction
 
 ```sh
-go install github.com/sivchari/containedctx/cmd/containedctx
+go install github.com/sivchari/containedctx/cmd/containedctx@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Without this PR:

```sh
$ go install github.com/sivchari/containedctx/cmd/containedctx

go: 'go install' requires a version when current directory is not in a module
        Try 'go install github.com/sivchari/containedctx/cmd/containedctx@latest' to install the latest version
```

Additionally, the PR fixes this CI failure:

<img width="1108" alt="image" src="https://github.com/user-attachments/assets/a4abd5b3-4970-4973-b2cd-3f47e2623bc1" />
